### PR TITLE
Add return value to callAPI & fix information messaging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Pandora
-Title: Retrieve Data using the API of the Pandora Data Platform
+Title: Retrieve Data using the API of the 'Pandora' Data Platform
 Version: 23.12.0
 Date: 2023-12-06
 Authors@R: c(

--- a/R/01-ckan.R
+++ b/R/01-ckan.R
@@ -330,6 +330,7 @@ strMatch <- function(dat, pattern) {
 #'  "mapping"
 #' @param ... parameters for the endpoint, e.g. all_fields = "true"
 #' 
+#' @return (data.frame) output from the Pandora API
 #' @export
 callAPI <- function(action = c("current_package_list_with_resources",
                                "group_list",

--- a/R/02-getData.R
+++ b/R/02-getData.R
@@ -2,6 +2,9 @@
 #'
 #' @param name (character) name of a resource, e.g. an entry of the output from
 #'  \code{getResources()$name}
+#' @param verbose Logical, indicating whether to display processing messages.
+#'   If TRUE, messages will be displayed; if FALSE, messages will be suppressed.
+#'   Default is TRUE.
 #' @param options (list) a list of extra options for \code{read.csv()} or \code{openxlsx::read.xlsx()} and
 #'  \code{readxl::read_excel}
 #' @inheritParams getResources
@@ -10,6 +13,7 @@
 #' @export
 getData <- function(name,
                     repository = "",
+                    verbose = TRUE,
                     options = dataOptions()) {
   resource <- try({
     getResources(repository = repository) %>%
@@ -28,7 +32,8 @@ getData <- function(name,
       dec = options$text$dec,
       fileEncoding = options$text$fileEncoding,
       colNames = options$colNames,
-      sheet = options$xlsx$sheet
+      sheet = options$xlsx$sheet,
+      verbose = verbose
     )
   }, silent = TRUE)
   
@@ -155,6 +160,7 @@ selectSingleFile <- function(resource) {
 #' @param type (character) type of file, one of \code{c("xlsx", "xls", "odt", "csv", "txt")}
 #' @inheritParams utils::read.csv
 #' @inheritParams openxlsx::read.xlsx
+#' @inheritParams getData
 #'
 #' @return (data.frame) data loaded from the file at path
 #' @export
@@ -166,7 +172,8 @@ loadData <-
            dec = ".",
            fileEncoding = "",
            colNames = TRUE,
-           sheet = 1) {
+           sheet = 1,
+           verbose = TRUE) {
     type <- match.arg(type)
     # empty result if an error occurs
     res <- list()
@@ -194,7 +201,7 @@ loadData <-
     }
     
     if (type %in% c("csv", "txt")) {
-      cat(sprintf("Encoding: '%s'.\n", fileEncoding))
+      if (verbose) message(sprintf("Encoding: '%s'.\n", fileEncoding))
       isOldROnWindows()
     }
     

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,3 +4,7 @@
 
 # * This is a initial CRAN release.
 # * changed Title field to be in title case
+#
+# * write 'Pandora' in title in single quotes 
+# * add return value to callAPI.Rd
+# * use message() in loadData() instead of cat()

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -84,11 +84,11 @@
 
 
     <p>Runge A, Neudecker A, Fernandes R (2023).
-<em>Pandora: Retrieve Data using the API of the Pandora Data Platform</em>.
+<em>Pandora: Retrieve Data using the API of the 'Pandora' Data Platform</em>.
 R package version 23.12.0, <a href="https://github.com/Pandora-IsoMemo/pandora-data" class="external-link">https://github.com/Pandora-IsoMemo/pandora-data</a>. 
 </p>
     <pre>@Manual{,
-  title = {Pandora: Retrieve Data using the API of the Pandora Data Platform},
+  title = {Pandora: Retrieve Data using the API of the 'Pandora' Data Platform},
   author = {Antonia Runge and Andreas Neudecker and Ricardo Fernandes},
   year = {2023},
   note = {R package version 23.12.0},

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -84,11 +84,11 @@
 
 
     <p>Runge A, Neudecker A, Fernandes R (2023).
-<em>Pandora: Retrieve Data using the 'Pandora' API</em>.
+<em>Pandora: Retrieve Data using the API of the Pandora Data Platform</em>.
 R package version 23.12.0, <a href="https://github.com/Pandora-IsoMemo/pandora-data" class="external-link">https://github.com/Pandora-IsoMemo/pandora-data</a>. 
 </p>
     <pre>@Manual{,
-  title = {Pandora: Retrieve Data using the 'Pandora' API},
+  title = {Pandora: Retrieve Data using the API of the Pandora Data Platform},
   author = {Antonia Runge and Andreas Neudecker and Ricardo Fernandes},
   year = {2023},
   note = {R package version 23.12.0},

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,13 +5,13 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Retrieve Data using the Pandora API • Pandora</title>
+<title>Retrieve Data using the API of the Pandora Data Platform • Pandora</title>
 <!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha256-bZLfwXAP04zRMK2BjiO8iu9pf4FbLqX6zitd+tIvLhE=" crossorigin="anonymous">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script><!-- bootstrap-toc --><link rel="stylesheet" href="bootstrap-toc.css">
 <script src="bootstrap-toc.js"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous">
 <!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script><!-- headroom.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
-<script src="pkgdown.js"></script><meta property="og:title" content="Retrieve Data using the Pandora API">
+<script src="pkgdown.js"></script><meta property="og:title" content="Retrieve Data using the API of the Pandora Data Platform">
 <meta property="og:description" content="API wrapper that contains functions to retrieve data from the Pandora databases. Web services for API: &lt;https://pandora.earth/&gt;. ">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   how-to-use-pandora-data: how-to-use-pandora-data.html
-last_built: 2023-12-18T21:36Z
+last_built: 2023-12-19T09:43Z
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   how-to-use-pandora-data: how-to-use-pandora-data.html
-last_built: 2023-12-15T12:25Z
+last_built: 2023-12-18T21:36Z
 

--- a/docs/reference/callAPI.html
+++ b/docs/reference/callAPI.html
@@ -81,6 +81,12 @@
 <dd><p>parameters for the endpoint, e.g. all_fields = "true"</p></dd>
 
 </dl></div>
+    <div id="value">
+    <h2>Value</h2>
+    
+
+<p>(data.frame) output from the Pandora API</p>
+    </div>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/getData.html
+++ b/docs/reference/getData.html
@@ -63,7 +63,7 @@
     </div>
 
     <div id="ref-usage">
-    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">getData</span><span class="op">(</span><span class="va">name</span>, repository <span class="op">=</span> <span class="st">""</span>, options <span class="op">=</span> <span class="fu"><a href="dataOptions.html">dataOptions</a></span><span class="op">(</span><span class="op">)</span><span class="op">)</span></span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">getData</span><span class="op">(</span><span class="va">name</span>, repository <span class="op">=</span> <span class="st">""</span>, verbose <span class="op">=</span> <span class="cn">TRUE</span>, options <span class="op">=</span> <span class="fu"><a href="dataOptions.html">dataOptions</a></span><span class="op">(</span><span class="op">)</span><span class="op">)</span></span></code></pre></div>
     </div>
 
     <div id="arguments">
@@ -76,6 +76,12 @@
 <dt>repository</dt>
 <dd><p>(character) name of a Pandora repository, e.g. an entry of the output from
 <code>getRepositories()$name</code></p></dd>
+
+
+<dt>verbose</dt>
+<dd><p>Logical, indicating whether to display processing messages.
+If TRUE, messages will be displayed; if FALSE, messages will be suppressed.
+Default is TRUE.</p></dd>
 
 
 <dt>options</dt>

--- a/docs/reference/loadData.html
+++ b/docs/reference/loadData.html
@@ -71,7 +71,8 @@
 <span>  dec <span class="op">=</span> <span class="st">"."</span>,</span>
 <span>  fileEncoding <span class="op">=</span> <span class="st">""</span>,</span>
 <span>  colNames <span class="op">=</span> <span class="cn">TRUE</span>,</span>
-<span>  sheet <span class="op">=</span> <span class="fl">1</span></span>
+<span>  sheet <span class="op">=</span> <span class="fl">1</span>,</span>
+<span>  verbose <span class="op">=</span> <span class="cn">TRUE</span></span>
 <span><span class="op">)</span></span></code></pre></div>
     </div>
 
@@ -115,6 +116,12 @@
 
 <dt>sheet</dt>
 <dd><p>The name or index of the sheet to read data from.</p></dd>
+
+
+<dt>verbose</dt>
+<dd><p>Logical, indicating whether to display processing messages.
+If TRUE, messages will be displayed; if FALSE, messages will be suppressed.
+Default is TRUE.</p></dd>
 
 </dl></div>
     <div id="value">

--- a/man/callAPI.Rd
+++ b/man/callAPI.Rd
@@ -16,6 +16,9 @@ callAPI(
 
 \item{...}{parameters for the endpoint, e.g. all_fields = "true"}
 }
+\value{
+(data.frame) output from the Pandora API
+}
 \description{
 Call API
 }

--- a/man/getData.Rd
+++ b/man/getData.Rd
@@ -4,7 +4,7 @@
 \alias{getData}
 \title{Get Data}
 \usage{
-getData(name, repository = "", options = dataOptions())
+getData(name, repository = "", verbose = TRUE, options = dataOptions())
 }
 \arguments{
 \item{name}{(character) name of a resource, e.g. an entry of the output from
@@ -12,6 +12,10 @@ getData(name, repository = "", options = dataOptions())
 
 \item{repository}{(character) name of a Pandora repository, e.g. an entry of the output from
 \code{getRepositories()$name}}
+
+\item{verbose}{Logical, indicating whether to display processing messages.
+If TRUE, messages will be displayed; if FALSE, messages will be suppressed.
+Default is TRUE.}
 
 \item{options}{(list) a list of extra options for \code{read.csv()} or \code{openxlsx::read.xlsx()} and
 \code{readxl::read_excel}}

--- a/man/loadData.Rd
+++ b/man/loadData.Rd
@@ -12,7 +12,8 @@ loadData(
   dec = ".",
   fileEncoding = "",
   colNames = TRUE,
-  sheet = 1
+  sheet = 1,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -40,6 +41,10 @@ loadData(
 \item{colNames}{If \code{TRUE}, the first row of data will be used as column names.}
 
 \item{sheet}{The name or index of the sheet to read data from.}
+
+\item{verbose}{Logical, indicating whether to display processing messages.
+If TRUE, messages will be displayed; if FALSE, messages will be suppressed.
+Default is TRUE.}
 }
 \value{
 (data.frame) data loaded from the file at path

--- a/tests/testthat/test-getData.R
+++ b/tests/testthat/test-getData.R
@@ -68,8 +68,6 @@ test_that("Test getData()", {
   if (isOldROnWindows()) {
     expect_true(nrow(getData(name = "IsoMedIta Humans 21-12-22 - CSV",
                              options = dataOptions(sep = ";"))) < 2000)
-    cat(nrow(getData(name = "IsoMedIta Humans 21-12-22 - CSV",
-                     options = dataOptions(sep = ";"))))
   } else {
     expect_true(nrow(getData(name = "IsoMedIta Humans 21-12-22 - CSV",
                              options = dataOptions(sep = ";"))) > 2000)


### PR DESCRIPTION
@arunge we need to fix the information messaging in `02-getData.R` see https://github.com/Pandora-IsoMemo/pandora-data/issues/1#issuecomment-1861669987

i already searched for all occurrences of `sprintf`:

```
R/01-ckan.R:256:    attr(emptyOut, "error") <- sprintf("Column '%s' not found!", 
R/02-getData.R:41:    stop(sprintf("An error occurred for resource with name '%s'", name))
R/02-getData.R:50:    msg <- sprintf("%s for resource with name '%s', %s", data[[1]], name, msg)
R/02-getData.R:53:    msg <- sprintf("%s for resource with name '%s'", attr(data, "error"), name)
R/02-getData.R:58:    msg <- sprintf("An error occurred for resource with name '%s'", name)
R/02-getData.R:101:    stop(sprintf("No resource found for repository '%s'", repository))
R/02-getData.R:115:    stop(sprintf("No resource found with name '%s'", name))
R/02-getData.R:129:    stop(sprintf(
R/02-getData.R:197:      cat(sprintf("Encoding: '%s'.\n", fileEncoding))
R/02-getData.R:257:      errorInfo <- sprintf("Encoding: '%s', seperator: '%s', dec character: '%s'.", 
```

Lets talk tomorrow about it